### PR TITLE
Adding reportMetadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,14 @@ MultiReporter.prototype = {
     }
     this.reporters.forEach(r => r.report(...args));
   },
+  reportMetadata: function (tag, metadata) {
+    const args = arguments;
+    this.reporters.forEach(r => {
+      if (r.reportMetadata && typeof r.reportMetadata === "function") {
+        r.reportMetadata(...args);
+      }
+    });
+  },
   finish: function () {
     const args = arguments;
     this.reporters.forEach(r => r.finish(...args));


### PR DESCRIPTION
Adding reportMetadata to pass metadata from the test run back to any reporter.

According to testem docs:
> In addition, an optional reportMetadata(tag, metadata) method gets called whenever an adapter emits a test-result-metadata event, allowing customized processing on metadata generated by your tests.

Example: https://github.com/testem/testem/tree/master/examples/metadata_reporter